### PR TITLE
fixed issue when using flutter_screenutil version higher than 3.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_screenutil: ^2.2.0
+  flutter_screenutil: ^3.2.0
   cached_network_image: ^2.2.0+1
   font_awesome_flutter: ^8.8.1
   intl: ^0.16.1


### PR DESCRIPTION
upgraded flutter_screenutil to  ^3.2.0

error message
```Running "flutter pub get" in "App_Name"...                     
Because school_ui_toolkit 4.0.0 depends on flutter_screenutil ^2.2.0 
and no versions of school_ui_toolkit match >4.0.0 <5.0.0,
school_ui_toolkit ^4.0.0 requires flutter_screenutil ^2.2.0.

So, because "App_Name" depends on both flutter_screenutil ^3.2.0 and school_ui_toolkit ^4.0.0,
version solving failed.
pub get failed (1; So, because "App_Name" depends on both flutter_screenutil ^3.2.0
and school_ui_toolkit ^4.0.0, version solving failed.)
exit code 1```