### PR TITLE
updated in /example and migrated to flutter_screenutil breaking changes 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "DockerRun.DisableAutoGenerateConfig": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "DockerRun.DisableAutoGenerateConfig": true
-}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,11 +17,11 @@ class UIExample extends StatelessWidget {
       ),
       builder: (context, child) {
         ScreenUtil.init(
-          context,
-          width: ScreenSize.width,
-          height: ScreenSize.height,
-          allowFontScaling: true,
-        );
+        context,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
+        allowFontScaling: true,
+      );
         return child;
       },
       home: UICatalog(),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -28,28 +28,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   file:
     dependency: transitive
     description:
@@ -103,7 +103,7 @@ packages:
       name: flutter_screenutil
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "3.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -150,14 +150,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   nepali_date_picker:
     dependency: "direct main"
     description:
@@ -178,7 +178,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.1"
   path_provider:
     dependency: transitive
     description:
@@ -260,7 +260,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.2"
   sqflite:
     dependency: transitive
     description:
@@ -281,21 +281,21 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.2"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   synchronized:
     dependency: transitive
     description:
@@ -309,21 +309,21 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   uuid:
     dependency: transitive
     description:
@@ -337,7 +337,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   xdg_directories:
     dependency: transitive
     description:
@@ -346,5 +346,5 @@ packages:
     source: hosted
     version: "0.1.0"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-186.0.dev"
   flutter: ">=1.17.0 <2.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   school_ui_toolkit:
     path: ../
 
-  flutter_screenutil: ^2.2.0
+  flutter_screenutil: ^3.2.0
   cached_network_image: ^2.2.0+1
   font_awesome_flutter: ^8.8.1
   intl: ^0.16.1

--- a/lib/src/assignment_card/assignment_card.dart
+++ b/lib/src/assignment_card/assignment_card.dart
@@ -35,8 +35,8 @@ class AssignmentCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/calendar/calendar.dart
+++ b/lib/src/calendar/calendar.dart
@@ -153,8 +153,8 @@ class _CalendarState extends State<Calendar>
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/calendar/calendar_date_element.dart
+++ b/lib/src/calendar/calendar_date_element.dart
@@ -26,8 +26,8 @@ class CalendarDateElement extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/custom_circular_progress/custom_circular_progress.dart
+++ b/lib/src/custom_circular_progress/custom_circular_progress.dart
@@ -16,8 +16,8 @@ class CustomCircularProgress extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/deadline_card/deadline_card.dart
+++ b/lib/src/deadline_card/deadline_card.dart
@@ -23,8 +23,8 @@ class DeadlineCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/event_card/event_card.dart
+++ b/lib/src/event_card/event_card.dart
@@ -28,8 +28,8 @@ class EventCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/featured_video_card/featured_video_card.dart
+++ b/lib/src/featured_video_card/featured_video_card.dart
@@ -24,8 +24,8 @@ class FeaturedVideoCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/highlighted_icon/highlighted_icon.dart
+++ b/lib/src/highlighted_icon/highlighted_icon.dart
@@ -20,8 +20,8 @@ class HighlightedIcon extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/information_tile_widget/information_tile_widget.dart
+++ b/lib/src/information_tile_widget/information_tile_widget.dart
@@ -42,8 +42,8 @@ class InformationTileWidget extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/label_card/label_card.dart
+++ b/lib/src/label_card/label_card.dart
@@ -24,8 +24,8 @@ class LabelCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/nepali_calendar/nepali_calendar.dart
+++ b/lib/src/nepali_calendar/nepali_calendar.dart
@@ -153,8 +153,8 @@ class _NepaliCalendarState extends State<NepaliCalendar>
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/notice_card/notice_card.dart
+++ b/lib/src/notice_card/notice_card.dart
@@ -26,8 +26,8 @@ class NoticeCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/outlined_button/outlined_button.dart
+++ b/lib/src/outlined_button/outlined_button.dart
@@ -23,8 +23,8 @@ class OutlinedButton extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/overlapping_button_card/overlapping_button_card.dart
+++ b/lib/src/overlapping_button_card/overlapping_button_card.dart
@@ -27,8 +27,8 @@ class OverlappingButtonCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/profile_card/profile_card.dart
+++ b/lib/src/profile_card/profile_card.dart
@@ -37,8 +37,8 @@ class ProfileCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/routine_card/routine_card.dart
+++ b/lib/src/routine_card/routine_card.dart
@@ -27,8 +27,8 @@ class RoutineCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/school_location_widget/school_location_widget.dart
+++ b/lib/src/school_location_widget/school_location_widget.dart
@@ -24,8 +24,8 @@ class SchoolLocationWidget extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/school_toolkit_button/school_toolkit_button.dart
+++ b/lib/src/school_toolkit_button/school_toolkit_button.dart
@@ -21,8 +21,8 @@ class SchoolToolkitButton extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/school_toolkit_card/school_toolkit_card.dart
+++ b/lib/src/school_toolkit_card/school_toolkit_card.dart
@@ -34,8 +34,8 @@ class SchoolToolkitCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/school_toolkit_role_button/school_toolkit_role_button.dart
+++ b/lib/src/school_toolkit_role_button/school_toolkit_role_button.dart
@@ -23,8 +23,8 @@ class SchoolToolkitRoleButton extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/school_toolkit_text_field/school_toolkit_text_field.dart
+++ b/lib/src/school_toolkit_text_field/school_toolkit_text_field.dart
@@ -38,8 +38,8 @@ class _SchoolToolkitTextFieldState extends State<SchoolToolkitTextField> {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/lib/src/video_list_tile_card/video_list_tile_card.dart
+++ b/lib/src/video_list_tile_card/video_list_tile_card.dart
@@ -34,8 +34,8 @@ class VideoListTileCard extends StatelessWidget {
     if (ScreenUtil() == null) {
       ScreenUtil.init(
         context,
-        width: ScreenSize.width,
-        height: ScreenSize.height,
+        designSize :Size( ScreenSize.width,
+         ScreenSize.height,),
         allowFontScaling: true,
       );
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -28,28 +28,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   file:
     dependency: transitive
     description:
@@ -96,7 +96,7 @@ packages:
       name: flutter_screenutil
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "3.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -136,14 +136,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   nepali_date_picker:
     dependency: "direct main"
     description:
@@ -164,7 +164,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.1"
   path_provider:
     dependency: transitive
     description:
@@ -239,7 +239,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.2"
   sqflite:
     dependency: transitive
     description:
@@ -260,21 +260,21 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.2"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   synchronized:
     dependency: transitive
     description:
@@ -288,21 +288,21 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   uuid:
     dependency: transitive
     description:
@@ -316,7 +316,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   xdg_directories:
     dependency: transitive
     description:
@@ -325,5 +325,5 @@ packages:
     source: hosted
     version: "0.1.0"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-186.0.dev"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"


### PR DESCRIPTION
upgraded flutter_screenutil to  ^3.2.0

error message
```Running "flutter pub get" in "App_Name"...                     
Because school_ui_toolkit 4.0.0 depends on flutter_screenutil ^2.2.0 
and no versions of school_ui_toolkit match >4.0.0 <5.0.0,
school_ui_toolkit ^4.0.0 requires flutter_screenutil ^2.2.0.

So, because "App_Name" depends on both flutter_screenutil ^3.2.0 and school_ui_toolkit ^4.0.0,
version solving failed.
pub get failed (1; So, because "App_Name" depends on both flutter_screenutil ^3.2.0
and school_ui_toolkit ^4.0.0, version solving failed.)
exit code 1```